### PR TITLE
Fix a really small typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Removes the rounded avatars, buttons, icons, etc. from Twitter and makes them sq
 
 ## Installation
 1. Download and extract the ZIP file from [**here**](https://github.com/InventivetalentDev/MakeTwitterSquareAgain/archive/master.zip)
-2. Open `chrome:extension` in a new Chrome Tab (or use Settings > More tools > Extensions)
+2. Open `chrome:extensions` in a new Chrome Tab (or use Settings > More tools > Extensions)
 3. Drop the extracted folder into the extensions tab
 4. **Done!**


### PR DESCRIPTION
`chrome:extension` gives an `ERR_INVALID_URL` error when you go to it. The correct URL is `chrome:extensions`.